### PR TITLE
sm6375-common: implement fast charge control HAL

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -362,6 +362,11 @@ PRODUCT_PACKAGES += \
     android.hardware.power-service.lineage-libperfmgr \
     libqti-perfd-client
 
+
+# Fast Charge HAL
+PRODUCT_PACKAGES += \
+    vendor.lineage.fastcharge@1.0-service.qcom
+
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/configs/powerhint.json:$(TARGET_COPY_OUT_VENDOR)/etc/powerhint.json
 

--- a/common.mk
+++ b/common.mk
@@ -362,7 +362,6 @@ PRODUCT_PACKAGES += \
     android.hardware.power-service.lineage-libperfmgr \
     libqti-perfd-client
 
-
 # Fast Charge HAL
 PRODUCT_PACKAGES += \
     vendor.lineage.fastcharge@1.0-service.qcom

--- a/fastcharge/1.0/Android.bp
+++ b/fastcharge/1.0/Android.bp
@@ -1,0 +1,34 @@
+//
+// Copyright (C) 2020-2024 The LineageOS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+cc_binary {
+    name: "vendor.lineage.fastcharge@1.0-service.qcom",
+    relative_install_path: "hw",
+    proprietary: true,
+    srcs: [
+        "FastCharge.cpp",
+        "service.cpp",
+    ],
+    init_rc: [ "vendor.lineage.fastcharge@1.0-service.qcom.rc" ],
+    vintf_fragments: [ "vendor.lineage.fastcharge@1.0-service.qcom.xml" ],
+    shared_libs: [
+        "libbase",
+        "libbinder",
+        "libcutils",
+        "libhidlbase",
+        "libutils",
+        "vendor.lineage.fastcharge@1.0",
+    ],
+}

--- a/fastcharge/1.0/FastCharge.cpp
+++ b/fastcharge/1.0/FastCharge.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2020-2024 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define LOG_TAG "fastcharge@1.0-service"
+#define FASTCHARGE_PATH "/sys/class/qcom-battery/restrict_chg"
+#define FASTCHARGE_DEFAULT_SETTING true
+
+#include "FastCharge.h"
+#include <android-base/logging.h>
+#include <cutils/properties.h>
+
+#include <fstream>
+#include <iostream>
+
+namespace vendor {
+namespace lineage {
+namespace fastcharge {
+namespace V1_0 {
+namespace implementation {
+
+static constexpr const char* kFastChargingProp = "persist.vendor.fastchg_enabled";
+
+/*
+ * Write value to path and close file.
+ */
+template <typename T>
+static void set(const std::string& path, const T& value) {
+    std::ofstream file(path);
+
+    if (!file) {
+        PLOG(ERROR) << "Failed to open: " << path;
+        return;
+    }
+
+    LOG(DEBUG) << "write: " << path << " value: " << value;
+
+    file << value << std::endl;
+
+    if (!file) {
+        PLOG(ERROR) << "Failed to write: " << path << " value: " << value;
+    }
+}
+
+template <typename T>
+static T get(const std::string& path, const T& def) {
+    std::ifstream file(path);
+
+    if (!file) {
+        PLOG(ERROR) << "Failed to open: " << path;
+        return def;
+    }
+
+    T result;
+
+    file >> result;
+
+    if (file.fail()) {
+        PLOG(ERROR) << "Failed to read: " << path;
+        return def;
+    } else {
+        LOG(DEBUG) << "read: " << path << " value: " << result;
+        return result;
+    }
+}
+
+FastCharge::FastCharge() {
+    setEnabled(property_get_bool(kFastChargingProp, FASTCHARGE_DEFAULT_SETTING));
+}
+
+Return<bool> FastCharge::isEnabled() {
+    return get(FASTCHARGE_PATH, 0) < 1;
+}
+
+Return<bool> FastCharge::setEnabled(bool enable) {
+    set(FASTCHARGE_PATH, enable ? 0 : 1);
+
+    bool enabled = isEnabled();
+    property_set(kFastChargingProp, enabled ? "true" : "false");
+
+    return enabled;
+}
+
+}  // namespace implementation
+}  // namespace V1_0
+}  // namespace fastcharge
+}  // namespace lineage
+}  // namespace vendor

--- a/fastcharge/1.0/FastCharge.h
+++ b/fastcharge/1.0/FastCharge.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020-2024 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <hidl/MQDescriptor.h>
+#include <hidl/Status.h>
+#include <vendor/lineage/fastcharge/1.0/IFastCharge.h>
+
+namespace vendor {
+namespace lineage {
+namespace fastcharge {
+namespace V1_0 {
+namespace implementation {
+
+using ::android::sp;
+using ::android::hardware::hidl_array;
+using ::android::hardware::hidl_memory;
+using ::android::hardware::hidl_string;
+using ::android::hardware::hidl_vec;
+using ::android::hardware::Return;
+using ::android::hardware::Void;
+
+using ::vendor::lineage::fastcharge::V1_0::IFastCharge;
+
+
+struct FastCharge : public IFastCharge {
+    FastCharge();
+
+    Return<bool> isEnabled() override;
+    Return<bool> setEnabled(bool enable) override;
+};
+
+}  // namespace implementation
+}  // namespace V1_0
+}  // namespace fastcharge
+}  // namespace lineage
+}  // namespace vendor

--- a/fastcharge/1.0/service.cpp
+++ b/fastcharge/1.0/service.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020-2024 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define LOG_TAG "fastcharge@1.0-service"
+
+#include <android-base/logging.h>
+#include <hidl/HidlTransportSupport.h>
+
+#include "FastCharge.h"
+
+using android::hardware::configureRpcThreadpool;
+using android::hardware::joinRpcThreadpool;
+
+using vendor::lineage::fastcharge::V1_0::IFastCharge;
+using vendor::lineage::fastcharge::V1_0::implementation::FastCharge;
+
+using android::OK;
+using android::status_t;
+
+int main() {
+    android::sp<FastCharge> service = new FastCharge();
+
+    configureRpcThreadpool(1, true);
+
+    status_t status = service->registerAsService();
+    if (status != OK) {
+        LOG(ERROR) << "Cannot register FastCharge HAL service.";
+        return 1;
+    }
+
+    LOG(INFO) << "FastCharge HAL service ready.";
+
+    joinRpcThreadpool();
+
+    LOG(ERROR) << "FastCharge HAL service failed to join thread pool.";
+    return 1;
+}

--- a/fastcharge/1.0/vendor.lineage.fastcharge@1.0-service.qcom.rc
+++ b/fastcharge/1.0/vendor.lineage.fastcharge@1.0-service.qcom.rc
@@ -1,0 +1,2 @@
+service vendor.fastcharge-hal-1-0 /vendor/bin/hw/vendor.lineage.fastcharge@1.0-service.qcom
+    class hal

--- a/fastcharge/1.0/vendor.lineage.fastcharge@1.0-service.qcom.rc
+++ b/fastcharge/1.0/vendor.lineage.fastcharge@1.0-service.qcom.rc
@@ -1,2 +1,3 @@
 service vendor.fastcharge-hal-1-0 /vendor/bin/hw/vendor.lineage.fastcharge@1.0-service.qcom
     class hal
+    user system

--- a/fastcharge/1.0/vendor.lineage.fastcharge@1.0-service.qcom.xml
+++ b/fastcharge/1.0/vendor.lineage.fastcharge@1.0-service.qcom.xml
@@ -1,0 +1,11 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>vendor.lineage.fastcharge</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IFastCharge</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+</manifest>

--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -114,3 +114,6 @@
 /sys/devices/virtual/input/input[0-9]+/wakeup[0-9]+(/.*)?                                 u:object_r:sysfs_wakeup:s0
 /sys/devices/platform/soc/[^*]+/wakeup/wakeup[0-9]+(/.*)?                                 u:object_r:sysfs_wakeup:s0
 /sys/devices/virtual/misc/[^*]+/wakeup[0-9]+(/.*)?                                        u:object_r:sysfs_wakeup:s0
+
+# Fast Charge HAL
+/vendor/bin/hw/vendor\.lineage\.fastcharge@1\.0-service\.qcom u:object_r:hal_lineage_fastcharge_default_exec:s0

--- a/sepolicy/vendor/hal_fastcharge_default.te
+++ b/sepolicy/vendor/hal_fastcharge_default.te
@@ -1,0 +1,6 @@
+# Allow read/write access to /sys/class/qcom-battery/.*
+allow hal_lineage_fastcharge_default sysfs_battery_supply:file rw_file_perms;
+allow hal_lineage_fastcharge_default sysfs_battery_supply:dir search;
+
+# Allow control of sysprop persist.vendor.fastchg_enabled
+set_prop(hal_lineage_fastcharge_default, vendor_fastcharge_prop)

--- a/sepolicy/vendor/property.te
+++ b/sepolicy/vendor/property.te
@@ -5,3 +5,6 @@ vendor_internal_prop(vendor_mot_fingerprint_prop);
 vendor_internal_prop(vendor_mot_hw_prop);
 vendor_internal_prop(vendor_mot_touch_prop);
 vendor_internal_prop(vendor_mot_nfc_prop);
+
+# For Fast Charge HAL
+vendor_internal_prop(vendor_fastcharge_prop)

--- a/sepolicy/vendor/property_contexts
+++ b/sepolicy/vendor/property_contexts
@@ -21,3 +21,6 @@ vendor.nfc.fw_status       u:object_r:vendor_mot_nfc_prop:s0
 persist.vendor.hardware.fingerprint            u:object_r:vendor_mot_fingerprint_prop:s0
 vendor.hw.fps.ident                            u:object_r:vendor_mot_fingerprint_prop:s0
 vendor.hw.fingerprint.status                   u:object_r:vendor_mot_fingerprint_prop:s0
+
+# Fast Charge
+persist.vendor.fastchg_enabled          u:object_r:vendor_fastcharge_prop:s0


### PR DESCRIPTION
This PR implements LineageOS's fast charge control HAL for Motorola SM6375 devices. Although I tested this on `Bangkk`, it should work on `Fogos` too since they share the same platform.

This HAL uses sysfs node `/sys/class/qcom-battery/restrict_chg` for fast charge contol. When `1` is
written to `restrict_chg`, the battery charging current is limited to 1A (the kernel default), which translates
to approximately 4.2W of charging power.

LineageOS fast charge HAL interface definition:  
https://github.com/LineageOS/android_hardware_lineage_interfaces/tree/lineage-22.0/fastcharge/1.0

This is adapted from an earlier implementation:  
https://review.lineageos.org/c/LineageOS/android_device_nokia_sdm660-common/+/365622